### PR TITLE
`highlight` cannot be customized in rmarkdown::html_vignette

### DIFF
--- a/vignettes/dermatitis.Rmd
+++ b/vignettes/dermatitis.Rmd
@@ -3,7 +3,6 @@ title: "Detecting Skin Diseases"
 author: "Mads Lindskou"
 output: 
   rmarkdown::html_vignette:
-    highligh: zenburn
     toc: true
     fig_height: 4
     fig_width: 4


### PR DESCRIPTION
As documented on the help page `?rmarkdown::html_vignette`. Thanks!

(For the record, we discovered this problem via https://github.com/rstudio/rmarkdown/issues/2321#issuecomment-1057222808)